### PR TITLE
Improve Windows CI performance with fork-safe vcpkg binary caching

### DIFF
--- a/.github/workflows/buildcheck.yaml
+++ b/.github/workflows/buildcheck.yaml
@@ -122,6 +122,14 @@ jobs:
           path: frontend-sdl2
           submodules: recursive
 
+      - name: Prepare vcpkg binary cache dir (forks)
+        if: github.repository != 'projectM-visualizer/frontend-sdl-cpp'
+        shell: pwsh
+        run: |
+          $cacheDir = Join-Path $env:GITHUB_WORKSPACE "vcpkg-binary-cache"
+          New-Item -ItemType Directory -Force -Path $cacheDir | Out-Null
+          Write-Host "Cache dir: $cacheDir"
+
       # Restore fork cache (file-based binary cache persisted by actions/cache)
       - name: Cache vcpkg binary cache (forks)
         if: github.repository != 'projectM-visualizer/frontend-sdl-cpp'
@@ -158,7 +166,6 @@ jobs:
         run: |
           Write-Host "Using local file-based binary cache (readwrite) for fork/PR"
           $cacheDir = Join-Path $env:GITHUB_WORKSPACE "vcpkg-binary-cache"
-          New-Item -ItemType Directory -Force -Path $cacheDir | Out-Null
           "VCPKG_DEFAULT_BINARY_CACHE=$cacheDir" | Out-File -FilePath $env:GITHUB_ENV -Append
           "VCPKG_BINARY_SOURCES=clear;files,$cacheDir,readwrite" | Out-File -FilePath $env:GITHUB_ENV -Append
 


### PR DESCRIPTION
This PR significantly reduces Windows CI build times by introducing a fork-safe vcpkg binary caching strategy while preserving the existing NuGet-based cache behavior for the upstream repository.

### What Changed

- Added a **file-based vcpkg binary cache** (`files,<dir>,readwrite`) for forks and PRs.
- Persisted the fork binary cache using `actions/cache`.
- Retained **NuGet (readwrite)** binary caching for the upstream repository.
- Scoped NuGet authentication to upstream only.
- Included vcpkg commit + manifest hash in the cache key to ensure proper cache invalidation.
- Added a small diagnostic step to verify fork cache restore behavior.

### Behavior by Repository

**Upstream (`projectM-visualizer/frontend-sdl-cpp`)**
- Uses existing NuGet binary cache (readwrite).
- Authenticates using `VCPKG_PACKAGES_TOKEN`.

**Forks / External PRs**
- Uses local file-based binary cache.
- Does not require NuGet authentication.
- Cache is persisted via GitHub Actions cache.

### Result

- Windows CI time reduced substantially on forks.
- vcpkg dependencies are restored instead of rebuilt.
- No impact to upstream NuGet workflow.
- Fork builds no longer attempt unauthorized NuGet pushes.

Closes #12