### PR TITLE
630:P1 Application enters and exits main render loop once

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,6 +62,66 @@ target_link_libraries(projectMSDL_testcorelib
 )
 
 # ======
+# Test-only core library WITHOUT RenderLoop
+# ======
+
+# Build a core library from production sources to test on
+add_library(projectMSDL_testcorelib_norenderloop
+    # Add .cpp files as needed for testing
+    # Examples:
+    # ${PROJECT_SOURCE_DIR}/src/SDLRenderingWindow.cpp
+    # ${PROJECT_SOURCE_DIR}/src/RenderLoop.cpp
+    # ${PROJECT_SOURCE_DIR}/src/ProjectMWrapper.cpp
+    # For now, we'll include a simple file just so this thing works. It can be removed if unneeded later.
+    ${PROJECT_SOURCE_DIR}/src/FPSLimiter.cpp
+    ${PROJECT_SOURCE_DIR}/src/ProjectMSDLApplication.cpp
+    ${PROJECT_SOURCE_DIR}/src/ProjectMWrapper.cpp
+    ${PROJECT_SOURCE_DIR}/src/SDLRenderingWindow.cpp
+    ${PROJECT_SOURCE_DIR}/src/AudioCapture.cpp
+)
+
+if (WIN32)
+    target_sources(projectMSDL_testcorelib_norenderloop PRIVATE
+        ${PROJECT_SOURCE_DIR}/src/AudioCaptureImpl_WASAPI.cpp
+    )
+    target_compile_definitions(projectMSDL_testcorelib_norenderloop PRIVATE
+        AUDIO_IMPL_HEADER="AudioCaptureImpl_WASAPI.h"
+        USE_GLEW
+    )
+else()
+    target_sources(projectMSDL_testcorelib_norenderloop PRIVATE
+        ${PROJECT_SOURCE_DIR}/src/AudioCaptureImpl_SDL.cpp
+    )
+    target_compile_definitions(projectMSDL_testcorelib_norenderloop PRIVATE
+        AUDIO_IMPL_HEADER="AudioCaptureImpl_SDL.h"
+    )
+endif()
+
+# Headers from the production source tree
+target_include_directories(projectMSDL_testcorelib_norenderloop
+    PUBLIC
+    ${PROJECT_SOURCE_DIR}/src
+)
+
+# Compile definitions that are commonly referenced
+target_compile_definitions(projectMSDL_testcorelib_norenderloop
+    PRIVATE
+    PROJECTMSDL_CONFIG_LOCATION="${DEFAULT_CONFIG_PATH}"
+    PROJECTMSDL_VERSION="${PROJECT_VERSION}"
+)
+
+# Linker set (add to this only when the linker asks)
+target_link_libraries(projectMSDL_testcorelib_norenderloop
+    PRIVATE
+    SDL2::SDL2
+    Poco::Util
+    Poco::Foundation
+    ProjectMSDL-GUI
+    ProjectMSDL-Notifications
+    libprojectM::playlist
+)
+
+# ======
 # Actual test subdirs 
 # Add to this when defining more testing directories
 # (To be kept in this file after integration of above code into src/CMakeLists.txt)

--- a/tests/renderer/CMakeLists.txt
+++ b/tests/renderer/CMakeLists.txt
@@ -1,6 +1,9 @@
 # Requires gtest, otherwise fail
 find_package(GTest 1.10 REQUIRED NO_MODULE)
 
+# ===
+# Integration Test
+# ===
 # Creation of executable for this specific test
 add_executable(projectMSDL-renderer-test
     RenderSmokeTest.cpp
@@ -16,3 +19,21 @@ target_link_libraries(projectMSDL-renderer-test
 
 # Add our test to the executable
 add_test(NAME projectMSDL-renderer-test COMMAND projectMSDL-renderer-test)
+
+
+# ===
+# Unit Test
+# ===
+# Unit test executable (fake RenderLoop via symbols in MainExecutionTest.cpp)
+add_executable(projectMSDL-mainexec-test
+    MainExecutionTest.cpp
+)
+
+target_link_libraries(projectMSDL-mainexec-test
+    PRIVATE
+    projectMSDL_testcorelib_norenderloop
+    GTest::gtest
+    GTest::gtest_main
+)
+
+add_test(NAME projectMSDL-mainexec-test COMMAND projectMSDL-mainexec-test)

--- a/tests/renderer/MainExecutionTest.cpp
+++ b/tests/renderer/MainExecutionTest.cpp
@@ -1,0 +1,56 @@
+#define SDL_MAIN_HANDLED 1
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <vector>
+#include <string>
+
+#include <Poco/Util/Application.h>
+#include <Poco/AutoPtr.h>
+
+#include "ProjectMSDLApplication.h"
+#include "RenderLoop.h"
+
+#include "AudioCapture.h"
+#include "ProjectMWrapper.h"
+#include "SDLRenderingWindow.h"
+#include "gui/ProjectMGUI.h"
+#include "notifications/QuitNotification.h"
+
+static int g_run_calls = 0;
+
+// RenderLoop.cpp is excluded from projectMSDL_testcorelib_norenderloop so we provide these symbols here.
+RenderLoop::RenderLoop()
+    : _audioCapture(Poco::Util::Application::instance().getSubsystem<AudioCapture>())
+    , _projectMWrapper(Poco::Util::Application::instance().getSubsystem<ProjectMWrapper>())
+    , _sdlRenderingWindow(Poco::Util::Application::instance().getSubsystem<SDLRenderingWindow>())
+    , _projectMGui(Poco::Util::Application::instance().getSubsystem<ProjectMGUI>())
+{
+}
+
+// RenderLoop has an observer bound to this method.
+void RenderLoop::QuitNotificationHandler(const Poco::AutoPtr<QuitNotification>&)
+{
+}
+
+void RenderLoop::Run()
+{
+    ++g_run_calls;
+}
+
+class TestableProjectMSDLApplication final : public ProjectMSDLApplication {
+public:
+    using ProjectMSDLApplication::main;
+};
+
+TEST(ProjectMSDLApplicationMain, CallsRenderLoopRunExactlyOnceAndReturnsExitSuccess)
+{
+    g_run_calls = 0;
+
+    TestableProjectMSDLApplication app;
+    const int rc = app.main(std::vector<std::string>{});
+
+    EXPECT_EQ(g_run_calls, 1);
+    EXPECT_EQ(rc, EXIT_SUCCESS);
+}


### PR DESCRIPTION
## Summary
Adds a unit test to protect the application's main execution path by ensuring that `ProjectMSDLApplication::main()` constructs a `RenderLoop`, calls `RenderLoop::Run()` exactly once, and returns with `EXIT_SUCCESS` when the loop completes normally.

## Changes
- Added `MainExecutionTest.cpp` under `/tests/renderer`.
  - Overrides `RenderLoop::Run()` to track invocation count
  - Verifies `Run()` is called exactly once
  - Verifies `main()` returns `EXIT_SUCCESS`
- Introduced a new test-only core library
  - `projectMSDL_testcorelib_norenderloop`
  - Mirrors `projectMSDL_testcorelib` but excludes `RenderLoop.cpp`
  - Links all required production subsystems to satisfy dependencies
- Updated `/tests/renderer/CMakeLists.txt` to split into two test executables

## Testing
- Configured project with `-DBUILD_TESTING=ON`
- Verified both test executables build successfully on WIndows 11
- Confirmed:
  - `projectMSDL-renderer-test` runs existing integration smoke test
  - `projectMSDL-mainexec-test` runs new unit test
- Verified via `ctest -C -V Debug` that `RenderLoop::Run()` is invoked exactly once and `main()` returns `EXIT_SUCCESS`

Closes #2 .