### PR TITLE
630:P2 Fix ImGui::Selectable selected argument in Settings audio device list

### DIFF
--- a/src/gui/SettingsWindow.cpp
+++ b/src/gui/SettingsWindow.cpp
@@ -562,7 +562,7 @@ void SettingsWindow::AudioDeviceSetting()
         {
             bool isSelected = device.first == currentIndex;
 
-            if (ImGui::Selectable(device.second.c_str(), "", isSelected))
+            if (ImGui::Selectable(device.second.c_str(), isSelected))
             {
                 _audioCapture.AudioDeviceIndex(device.first);
                 if (device.first == -1)


### PR DESCRIPTION
Closes #28

## Summary of Changes
- Fixed the `ImGui::Selectable` call in `Settings -> Audio` so the `selected` argument is a real boolean.
- Changed:
  - From: `ImGui::Selectable(device.second.c_str(), "", isSelected)`
  - To: `ImGui::Selectable(device.second.c_str(), isSelected)`
- Scope is intentionally minimal: argument type/order fix only, no UX redesign.

## Verification
- **Build**
  - Ran CMake build successfully (result code `0`).
- **Static Analysis**
  - Ran focused cppcheck on `src/gui/SettingsWindow.cpp`.
  - `incorrectStringBooleanError` is no longer reported for the affected line.
- **Manual Checks**
  - In `Settings -> Audio`, selecting devices updates selection correctly.
  - Saving in Settings persists selected audio device across restart.
  - Confirmed Options menu behavior is separate from this issue and unchanged by this fix.

## Evidence
- **Before**
  - Cppcheck warning: `incorrectStringBooleanError`
  - Message: conversion of string literal `""` to `bool` always evaluates to true.
  - Problematic call:
    - `ImGui::Selectable(device.second.c_str(), "", isSelected)`
- **After**
  - Updated call:
    - `ImGui::Selectable(device.second.c_str(), isSelected)`
  - Focused cppcheck no longer reports `incorrectStringBooleanError` for this location.
- **Why this resolves issue #28**
  - The `selected` parameter now receives the intended boolean state (`isSelected`) instead of a non-null pointer converted to `true`.

## Time Log
- Triage & understanding: `0:30`
- Plan: `0:15`
- Implementation: `0:15`
- Verification: `0:30`
- PR overhead: `0:15`