### PR TITLE
630:P2 Refactor FPSLimiter timing magic numbers into named constants

### DIFF
--- a/src/FPSLimiter.cpp
+++ b/src/FPSLimiter.cpp
@@ -2,11 +2,17 @@
 
 #include <SDL2/SDL.h>
 
+namespace
+{
+constexpr uint32_t kMillisecondsPerSecond = 1000;  // Convert FPS to millisecond frame duration
+constexpr uint32_t kFrameHistorySize = 10;         // Rolling average window for FPS calculation
+}  // namespace
+
 void FPSLimiter::TargetFPS(int fps)
 {
     if (fps)
     {
-        _targetFrameTime = 1000 / fps;
+        _targetFrameTime = kMillisecondsPerSecond / fps;
     }
     else
     {
@@ -33,7 +39,7 @@ float FPSLimiter::FPS() const
         return 0.0f;
     }
 
-   return 1000.0f / (static_cast<float>(frameTimeSum) / static_cast<float>(frameTimeCount));
+   return static_cast<float>(kMillisecondsPerSecond) / (static_cast<float>(frameTimeSum) / static_cast<float>(frameTimeCount));
 }
 
 void FPSLimiter::StartFrame()
@@ -52,5 +58,5 @@ void FPSLimiter::EndFrame()
     }
 
     _lastFrameTimes[_nextFrameTimesOffset] = frameTime;
-    _nextFrameTimesOffset = (_nextFrameTimesOffset + 1) % 10;
+    _nextFrameTimesOffset = (_nextFrameTimesOffset + 1) % kFrameHistorySize;
 }

--- a/src/FPSLimiter.h
+++ b/src/FPSLimiter.h
@@ -45,5 +45,3 @@ protected:
     int _nextFrameTimesOffset{ 0 }; //!< Next offset to overwrite the _lastFrameTimes ring buffer.
 
 };
-
-


### PR DESCRIPTION
Closes #30

## Summary of Changes
- Replaced timing-related magic numbers in `src/FPSLimiter.cpp` with named `constexpr` constants in an anonymous namespace:
  - `kMillisecondsPerSecond`
  - `kFrameHistorySize`
- Updated FPS target frame-time conversion and FPS calculation to use named constants.
- Updated frame-history ring-buffer modulo logic to use named constant.
- Added brief inline comments to clarify unit semantics and intent.
- No behavior change intended to FPS limiting logic.

## Verification
- Clean build:
  - `rm -rf build`
  - `cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`
  - `cmake --build build`
  - Result: success
- Focused static analysis:
  - `cppcheck --enable=warning,style --std=c++17 src/FPSLimiter.cpp`
  - Result: no warnings for `src/FPSLimiter.cpp`
- Manual UI/runtime checks:
  - Verified Target FPS changes apply at runtime.
  - Verified Target FPS changes persist after app restart.
  - Verified Target FPS reset button behavior works as expected.

## Evidence
- Before: `FPSLimiter.cpp` had hardcoded timing literals (e.g., `1000`, `1000.0f`, `10`) flagged as readability magic numbers.
- After: literals replaced with explicit named constants (`kMillisecondsPerSecond`, `kFrameHistorySize`) with unchanged values and behavior.
- Follow-up note (out of scope for #30): while validating UI, `Esc` was not delivered as an SDL key event on this macOS environment (Implemented temporary key trace logic for debugging and building with `PROJECTM_TRACE_KEYS=1` showed other keys like `n/p` but no `Esc`).  `Esc` is intended to be used for toggling the menu bar UI, and due to this bug, the menu bar could not be viewed without a workaround.
  A local-only temporary workaround key to toggle menu bar visibility was used for manual UI verification and is not intended as part of this issue’s committed behavior fix.

## Time Log
- Triage & understanding: 15 minutes
- Plan: 15 minutes
- Implementation: 15 minutes
- Verification: 45 minutes
- PR overhead: 15 minutes

Note: Extended verification time due to `Esc` key bug, which was a bottleneck for manual verification.