### PR TITLE
630:P3 Addressed code logic spaghetti in filechooser

### DIFF
--- a/src/gui/FileChooser.cpp
+++ b/src/gui/FileChooser.cpp
@@ -330,27 +330,42 @@ void FileChooser::ChangeDirectory(Poco::Path newDirectory)
             poco_debug_f2(_logger, "Skipping inaccessible path %s: %s", directoryIterator.path().toString(), ex.displayText());
         }
 
-        if ((!isHidden || _showHidden))
+        if ((!isHidden || _showHidden) && AcceptEntry(directoryIterator.path(), isDirectory))
         {
-            if ((_mode != Mode::Directory && _extensions.empty()) || isDirectory)
-            {
-                _currentFileList.push_back(*directoryIterator);
-            }
-            else if (_mode != Mode::Directory)
-            {
-                auto fileExtension = directoryIterator.path().getExtension();
-                for (const auto& extension : _extensions)
-                {
-                    if (Poco::icompare(directoryIterator.path().getExtension(), extension) != 0)
-                    {
-                        _currentFileList.push_back(*directoryIterator);
-                    }
-                }
-            }
+            _currentFileList.push_back(*directoryIterator);
         }
 
         ++directoryIterator;
     }
+}
+
+bool FileChooser::AcceptEntry(const Poco::Path& path, bool isDirectory) const
+{
+    if (isDirectory)
+    {
+        return true;
+    }
+
+    if (_mode == Mode::Directory)
+    {
+        return false;
+    }
+
+    if (_extensions.empty())
+    {
+        return true;
+    }
+
+    auto fileExtension = path.getExtension();
+    for (const auto& extension : _extensions)
+    {
+        if (Poco::icompare(fileExtension, extension) == 0)
+        {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 void FileChooser::UpdateListSelection(int index, bool isSelected)

--- a/src/gui/FileChooser.h
+++ b/src/gui/FileChooser.h
@@ -122,6 +122,15 @@ protected:
     bool PopulateFileList();
 
     /**
+     * @brief Determines whether a directory entry should be shown in the file list.
+     *
+     * @param path The path of the directory entry.
+     * @param isDirectory True if the entry is a directory.
+     * @return True if the entry should be included in the current file list.
+     */
+    bool AcceptEntry(const Poco::Path& path, bool isDirectory) const;
+
+    /**
      * @brief Changes the currently displayed directory to the given path.
      *
      * The path must not necessarily exist or be accessible. A message is shown to the user if something is wrong.


### PR DESCRIPTION
Closes #56 

### Summary
Refactored `FileChooser` filtering so file acceptance policy is removed from inline directory traversal in `src/gui/FileChooser.cpp`. The traversal loop now delegates file/directory inclusion to a dedicated predicate, improving clarity and correctness.

### Design Pattern
- Used a small **Strategy/Predicate**-style approach.
- Encapsulated acceptance policy in `FileChooser::AcceptEntry(const Poco::Path& path, bool isDirectory) const`.

### Verification
- Build verified successfully with CMake / Visual Studio Debug target.
- Manual test evidence: the program continues to run as expected after the refactor.
- All included tests passed in the workspace.

### Evidence
- Changed `src/gui/FileChooser.cpp`:
  - removed brittle inline extension loop in `ChangeDirectory`
  - added `AcceptEntry(...)` helper
- Changed `src/gui/FileChooser.h`:
  - added private acceptance helper declaration
- Fix addresses the prior incorrect logic where entries were added on non-match instead of match.