### PR TITLE
630:P3 Addressed code duplication in WASAPI

### DIFF
--- a/src/AudioCaptureImpl_WASAPI.cpp
+++ b/src/AudioCaptureImpl_WASAPI.cpp
@@ -8,6 +8,42 @@
 #include <mmdeviceapi.h>
 #include <objbase.h>
 
+// Helper that centralizes WASAPI enumerator acquisition, device list creation,
+// and cleanup for the AudioCaptureImpl WASAPI backend.
+class WASAPIDeviceCatalog
+{
+    public:
+        explicit WASAPIDeviceCatalog(const AudioCaptureImpl& audioCaptureImpl)
+            : _audioCaptureImpl(audioCaptureImpl)
+            , _enumerator(audioCaptureImpl.GetDeviceEnumerator())
+        {
+        }
+
+        ~WASAPIDeviceCatalog()
+        {
+            // Release the COM enumerator automatically when this object goes out of scope.
+            if (_enumerator)
+            {
+                _enumerator->Release();
+            }
+        }
+
+        std::vector<AudioCaptureImpl::AudioDevice> DeviceList() const
+        {
+            if (_enumerator == nullptr)
+            {
+                return {};
+            }
+
+            // Delegate actual device list construction to the single source of truth.
+            return _audioCaptureImpl.GetAudioDeviceList(_enumerator);
+        }
+
+    private:
+        const AudioCaptureImpl& _audioCaptureImpl;
+        IMMDeviceEnumerator* _enumerator{nullptr};
+};
+
 AudioCaptureImpl::AudioCaptureImpl()
     : _captureThread(this, &AudioCaptureImpl::CaptureThread)
 {
@@ -24,9 +60,8 @@ std::map<int, std::string> AudioCaptureImpl::AudioDeviceList()
     std::map<int, std::string> deviceList{
         {-1, _defaultDeviceName}};
 
-    IMMDeviceEnumerator* enumerator{GetDeviceEnumerator()};
-    auto captureDevices{GetAudioDeviceList(enumerator)};
-    enumerator->Release();
+    WASAPIDeviceCatalog deviceCatalog(*this);
+    auto captureDevices = deviceCatalog.DeviceList();
 
     uint32_t index{0};
     for (const auto& device : captureDevices)
@@ -67,9 +102,8 @@ void AudioCaptureImpl::NextAudioDevice()
 {
     StopRecording();
 
-    IMMDeviceEnumerator* enumerator{GetDeviceEnumerator()};
-    auto captureDevices{GetAudioDeviceList(enumerator)};
-    enumerator->Release();
+    WASAPIDeviceCatalog deviceCatalog(*this);
+    auto captureDevices = deviceCatalog.DeviceList();
 
     // Will wrap around to loopback capture device (-1).
     int nextAudioDeviceId = ((_currentAudioDeviceIndex + 2) % (static_cast<int>(captureDevices.size()) + 1)) - 1;
@@ -79,9 +113,8 @@ void AudioCaptureImpl::NextAudioDevice()
 
 void AudioCaptureImpl::AudioDeviceIndex(int index)
 {
-    IMMDeviceEnumerator* enumerator{GetDeviceEnumerator()};
-    auto captureDevices{GetAudioDeviceList(enumerator)};
-    enumerator->Release();
+    WASAPIDeviceCatalog deviceCatalog(*this);
+    auto captureDevices = deviceCatalog.DeviceList();
 
     if (index >= -1 && index < static_cast<int>(captureDevices.size()))
     {
@@ -103,9 +136,8 @@ std::string AudioCaptureImpl::AudioDeviceName() const
         return "System Default Audio Device";
     }
 
-    IMMDeviceEnumerator* enumerator{GetDeviceEnumerator()};
-    auto captureDevices{GetAudioDeviceList(enumerator)};
-    enumerator->Release();
+    WASAPIDeviceCatalog deviceCatalog(*this);
+    auto captureDevices = deviceCatalog.DeviceList();
 
     if (captureDevices.empty() || _currentAudioDeviceIndex >= static_cast<int>(captureDevices.size()))
     {
@@ -629,9 +661,8 @@ HRESULT AudioCaptureImpl::OnDeviceStateChanged(LPCWSTR pwstrDeviceId, DWORD dwNe
     // Recalculate current device index and restart only if not default.
     if (_currentAudioDeviceIndex >= 0)
     {
-        IMMDeviceEnumerator* enumerator{GetDeviceEnumerator()};
-        auto captureDevices{GetAudioDeviceList(enumerator)};
-        enumerator->Release();
+        WASAPIDeviceCatalog deviceCatalog(*this);
+        auto captureDevices = deviceCatalog.DeviceList();
 
         for (int index = 0; index < captureDevices.size(); ++index)
         {

--- a/src/AudioCaptureImpl_WASAPI.cpp
+++ b/src/AudioCaptureImpl_WASAPI.cpp
@@ -28,6 +28,14 @@ class WASAPIDeviceCatalog
             }
         }
 
+        // Non-copyable: prevent double-release of COM pointer
+        WASAPIDeviceCatalog(const WASAPIDeviceCatalog&) = delete;
+        WASAPIDeviceCatalog& operator=(const WASAPIDeviceCatalog&) = delete;
+
+        // Non-movable: enforce single ownership of enumerator
+        WASAPIDeviceCatalog(WASAPIDeviceCatalog&&) = delete;
+        WASAPIDeviceCatalog& operator=(WASAPIDeviceCatalog&&) = delete;
+
         std::vector<AudioCaptureImpl::AudioDevice> DeviceList() const
         {
             if (_enumerator == nullptr)

--- a/src/AudioCaptureImpl_WASAPI.h
+++ b/src/AudioCaptureImpl_WASAPI.h
@@ -177,6 +177,8 @@ protected:
      * @param enumerator The enumerator interface to use.
      * @return A vector of AudioDevice entries, each representing an available audio device.
      */
+    friend class WASAPIDeviceCatalog;
+
     std::vector<AudioDevice> GetAudioDeviceList(IMMDeviceEnumerator* enumerator) const;
 
     /**


### PR DESCRIPTION
Closes #60 

### Summary
Refactored WASAPI device enumeration in `src/AudioCaptureImpl_WASAPI.cpp` to remove duplicated enumerator setup and cleanup. Added a small helper class, `WASAPIDeviceCatalog`, that:
- acquires `IMMDeviceEnumerator`
- retrieves the audio device list via `GetAudioDeviceList()`
- releases the enumerator automatically in its destructor

This centralizes enumerator handling and keeps device-list creation logic in one place.

### Design Pattern
- Pattern used: **Facade**
- Why: `WASAPIDeviceCatalog` provides a simplified interface for WASAPI device enumeration, hiding enumerator acquisition and cleanup behind a single helper.

### Verification
- Build verified successfully with CMake / Visual Studio Debug target.
- Manual test evidence: the program continues to run as expected after the refactor.
- All included tests passed in the workspace.

### Evidence
- `src/AudioCaptureImpl_WASAPI.cpp` now contains `WASAPIDeviceCatalog`.
- Refactored call sites:
  - `AudioDeviceList()`
  - `NextAudioDevice()`
  - `AudioDeviceIndex(int)`
  - `AudioDeviceName() const`
  - `OnDeviceStateChanged(LPCWSTR, DWORD)`
- The previous repeated pattern `GetDeviceEnumerator()` / `GetAudioDeviceList()` / `Release()` is removed from those places.