### PR TITLE
630:P3 Issue 50: Extract Config Migration Module and Align Fullscreen Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ can also create a user configuration file in your user's home directory. Dependi
 - macOS: `~/Library/Preferences/projectM/projectMSDL.properties`
 
 You can copy the [config file template](src/resources/projectMSDL.properties.in) there and change anything in `@@`.
+Any legacy configuration keys from older configs are migrated to canonical key names on startup.
 
 Depending on the build system, you'll find the projectM executable in `cmake-build/src/`, or a subdirectory with the
 name of your build type (`Release`, `Debug` and so on).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(notifications)
+add_subdirectory(config)
 add_subdirectory(gui)
 
 find_package(OpenGL REQUIRED)
@@ -90,6 +91,7 @@ endif()
 
 target_link_libraries(projectMSDL
         PRIVATE
+        ProjectMSDL-Config
         ProjectMSDL-GUI
         ProjectMSDL-Notifications
         libprojectM::playlist

--- a/src/ProjectMSDLApplication.cpp
+++ b/src/ProjectMSDLApplication.cpp
@@ -8,6 +8,7 @@
 #include "ProjectMWrapper.h"
 #include "RenderLoop.h"
 #include "SDLRenderingWindow.h"
+#include "config/ConfigMigration.h"
 #include "gui/ProjectMGUI.h"
 
 #include <Poco/Environment.h>
@@ -96,6 +97,7 @@ void ProjectMSDLApplication::initialize(Poco::Util::Application& self)
             Poco::File(userConfigurationFile).createFile();
         }
         _userConfiguration->load(userConfigurationFile.toString());
+        ConfigMigration::ApplyUserConfigKeyMigrations(*_userConfiguration, logger());
         config().add(_userConfiguration, PRIO_DEFAULT - 10);
 
         // Store the configuration file path

--- a/src/SDLRenderingWindow.cpp
+++ b/src/SDLRenderingWindow.cpp
@@ -76,10 +76,10 @@ void SDLRenderingWindow::Fullscreen()
 {
     SDL_GetWindowSize(_renderingWindow, &_lastWindowWidth, &_lastWindowHeight);
     SDL_ShowCursor(false);
-    if (_config->getBool("fullscreen.exclusiveMode", false))
+    if (_config->getBool("window.fullscreen.exclusiveMode", false))
     {
-        int fullscreenWidth = _config->getInt("fullscreen.width", 0);
-        int fullscreenHeight = _config->getInt("fullscreen.height", 0);
+        int fullscreenWidth = _config->getInt("window.fullscreen.width", 0);
+        int fullscreenHeight = _config->getInt("window.fullscreen.height", 0);
         if (fullscreenWidth > 0 && fullscreenHeight > 0)
         {
             SDL_RestoreWindow(_renderingWindow);

--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_library(ProjectMSDL-Config STATIC
+        ConfigMigration.cpp
+        ConfigMigration.h
+        )
+
+target_include_directories(ProjectMSDL-Config
+        PUBLIC
+        "${CMAKE_SOURCE_DIR}/src"
+        )
+
+target_link_libraries(ProjectMSDL-Config
+        PUBLIC
+        Poco::Util
+        )

--- a/src/config/ConfigMigration.cpp
+++ b/src/config/ConfigMigration.cpp
@@ -1,0 +1,56 @@
+#include "config/ConfigMigration.h"
+
+#include <array>
+#include <string>
+
+namespace
+{
+struct ConfigKeyMigration
+{
+    const char* legacyKey;
+    const char* canonicalKey;
+};
+
+// Keep startup key migrations centralized so future schema updates are append-only.
+constexpr std::array<ConfigKeyMigration, 3> kUserConfigKeyMigrations{{
+    {"window.fullscreen.exclusive", "window.fullscreen.exclusiveMode"},
+    {"fullscreen.width", "window.fullscreen.width"},
+    {"fullscreen.height", "window.fullscreen.height"},
+}};
+
+bool ApplyUserConfigKeyMigration(Poco::Util::PropertyFileConfiguration& userConfig,
+                                 const ConfigKeyMigration& migration)
+{
+    if (userConfig.has(migration.canonicalKey) || !userConfig.has(migration.legacyKey))
+    {
+        return false;
+    }
+
+    userConfig.setString(migration.canonicalKey, userConfig.getString(migration.legacyKey));
+    return true;
+}
+} // namespace
+
+void ConfigMigration::ApplyUserConfigKeyMigrations(Poco::Util::PropertyFileConfiguration& userConfig,
+                                                   Poco::Logger& logger)
+{
+    int appliedMigrationCount{0};
+    for (const auto& migration : kUserConfigKeyMigrations)
+    {
+        if (ApplyUserConfigKeyMigration(userConfig, migration))
+        {
+            ++appliedMigrationCount;
+            poco_information_f2(logger,
+                                "Migrated legacy user config key '%s' to canonical key '%s'.",
+                                std::string(migration.legacyKey),
+                                std::string(migration.canonicalKey));
+        }
+    }
+
+    if (appliedMigrationCount > 0)
+    {
+        poco_information_f1(logger,
+                            "Applied %?d startup user config key migration(s).",
+                            appliedMigrationCount);
+    }
+}

--- a/src/config/ConfigMigration.h
+++ b/src/config/ConfigMigration.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <Poco/Logger.h>
+#include <Poco/Util/PropertyFileConfiguration.h>
+
+namespace ConfigMigration
+{
+/**
+ * @brief Applies startup migrations from legacy user-config keys to canonical keys.
+ *
+ * The migration table is append-only: add new key pairs as configuration naming
+ * evolves in follow-up issues, while keeping migration behavior centralized.
+ *
+ * @param userConfig Loaded user configuration to migrate in-place.
+ * @param logger Logger used to report applied migrations.
+ */
+void ApplyUserConfigKeyMigrations(Poco::Util::PropertyFileConfiguration& userConfig, Poco::Logger& logger);
+
+} // namespace ConfigMigration

--- a/src/gui/SettingsConfigKeys.h
+++ b/src/gui/SettingsConfigKeys.h
@@ -3,6 +3,8 @@
 namespace SettingsConfigKeys
 {
 
+// Canonical config keys are fully-qualified and must match projectMSDL.properties.in.
+
 constexpr char kConfigProjectMPresetPath[] = "projectM.presetPath";
 constexpr char kConfigProjectMTexturePath[] = "projectM.texturePath";
 constexpr char kConfigProjectMEnableSplash[] = "projectM.enableSplash";
@@ -30,14 +32,14 @@ constexpr char kConfigWindowOverridePosition[] = "window.overridePosition";
 constexpr char kConfigWindowMonitor[] = "window.monitor";
 constexpr char kConfigWindowBorderless[] = "window.borderless";
 constexpr char kConfigWindowFullscreen[] = "window.fullscreen";
-constexpr char kConfigWindowFullscreenExclusive[] = "window.fullscreen.exclusive";
+constexpr char kConfigWindowFullscreenExclusive[] = "window.fullscreen.exclusiveMode";
 constexpr char kConfigWindowWaitForVerticalSync[] = "window.waitForVerticalSync";
 constexpr char kConfigWindowAdaptiveVerticalSync[] = "window.adaptiveVerticalSync";
 constexpr char kConfigWindowDisplayPresetNameInTitle[] = "window.displayPresetNameInTitle";
 constexpr char kConfigWindowUiScale[] = "window.uiScale";
 
-constexpr char kConfigFullscreenWidth[] = "fullscreen.width";
-constexpr char kConfigFullscreenHeight[] = "fullscreen.height";
+constexpr char kConfigFullscreenWidth[] = "window.fullscreen.width";
+constexpr char kConfigFullscreenHeight[] = "window.fullscreen.height";
 
 constexpr char kConfigAudioDevice[] = "audio.device";
 constexpr char kConfigAppUserConfigurationFile[] = "app.UserConfigurationFile";

--- a/src/resources/projectMSDL.properties.in
+++ b/src/resources/projectMSDL.properties.in
@@ -17,6 +17,10 @@ window.monitor = 0
 #             Does not change the current resolution.
 # - exclusive: Sets the resolution to window.fullscreen.width/height and runs in exclusive mode,
 #              like a game.
+# Legacy keys from older configs are migrated on startup to improve codebase consistency:
+# window.fullscreen.exclusive -> window.fullscreen.exclusiveMode
+# fullscreen.width -> window.fullscreen.width
+# fullscreen.height -> window.fullscreen.height
 window.fullscreen.exclusiveMode = false
 
 # Only used if fullscreen mode is "exclusive"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -58,6 +58,7 @@ target_link_libraries(projectMSDL_testcorelib
     SDL2::SDL2
     Poco::Util
     Poco::Foundation
+    ProjectMSDL-Config
     ProjectMSDL-GUI
     ProjectMSDL-Notifications
     libprojectM::playlist
@@ -118,6 +119,7 @@ target_link_libraries(projectMSDL_testcorelib_norenderloop
     SDL2::SDL2
     Poco::Util
     Poco::Foundation
+    ProjectMSDL-Config
     ProjectMSDL-GUI
     ProjectMSDL-Notifications
     libprojectM::playlist


### PR DESCRIPTION
Closes #50

### Summary
Refactored fullscreen/window config key handling to eliminate shotgun edits across the frontend and preserve legacy compatibility.

- Aligned key usage to canonical names:
  - `window.fullscreen.exclusive` -> `window.fullscreen.exclusiveMode`
  - `fullscreen.width` -> `window.fullscreen.width`
  - `fullscreen.height` -> `window.fullscreen.height`
- Added a startup migration module in `src/config/`:
  - `src/config/ConfigMigration.h`
  - `src/config/ConfigMigration.cpp`
  - `src/config/CMakeLists.txt`
- Wired migration execution into startup in `src/ProjectMSDLApplication.cpp`.
- Updated fullscreen runtime config reads in `src/SDLRenderingWindow.cpp` to canonical keys.
- Added build wiring for `ProjectMSDL-Config` in `src/CMakeLists.txt`.
- Documented compatibility behavior in `src/resources/projectMSDL.properties.in` and `README.md`.
- Addressed review feedback for test build linkage:
  - Added `ProjectMSDL-Config` to both test core-library link blocks in `tests/CMakeLists.txt`.

### Design Pattern
- Pattern used: **Adapter** (Structural)
- Why: Introduced a centralized legacy-to-canonical mapping adapter (`ConfigMigration`) so legacy config keys are translated at startup while runtime call sites use canonical keys.

### Verification
- Build verified successfully.
- Migration smoke verified in a sandbox HOME with legacy keys; logs confirmed all three key migrations were applied.
- Targeted legacy-key scan confirmed no remaining non-migration/raw-template usage of old fullscreen keys.
- Test build verification with testing enabled:
  - Reconfigured with `-DBUILD_TESTING=ON`.
  - Built test targets successfully, including `projectMSDL_testcorelib` and `projectMSDL_testcorelib_norenderloop`.
  - CTest executables passed:
    - `projectMSDL-audio-tests`
    - `projectMSDL-cli-test`
    - `projectMSDL-mainexec-test`
    - `projectMSDL-renderer-test`
    - `projectMSDL-ui-test`
- Scope note:
  - Fullscreen click/hover misalignment remains tracked separately in #64.

### Evidence
- `src/gui/SettingsConfigKeys.h` now uses canonical fullscreen key constants.
- `src/SDLRenderingWindow.cpp` now reads canonical fullscreen keys at runtime.
- `src/config/ConfigMigration.cpp` contains the centralized migration table for:
  - `window.fullscreen.exclusive` -> `window.fullscreen.exclusiveMode`
  - `fullscreen.width` -> `window.fullscreen.width`
  - `fullscreen.height` -> `window.fullscreen.height`
- `src/ProjectMSDLApplication.cpp` applies migration immediately after loading user config.
- Canonical defaults and migration note are reflected in `src/resources/projectMSDL.properties.in`.
- Test linking update is reflected in `tests/CMakeLists.txt`.

### Scope Notes
- Migration logic remains append-only and centralized so follow-up schema changes can add entries without touching runtime call sites.
