### PR TITLE
630:P3 Refactor window config usage through facade

### DIFF
--- a/src/SDLRenderingWindow.cpp
+++ b/src/SDLRenderingWindow.cpp
@@ -2,6 +2,7 @@
 
 #include "ProjectMSDLApplication.h"
 #include "ProjectMWrapper.h"
+#include "config/SettingsConfigKeys.h"
 
 #include <Poco/Delegate.h>
 #include <Poco/NotificationCenter.h>
@@ -23,7 +24,8 @@ void SDLRenderingWindow::initialize(Poco::Util::Application& app)
 {
     auto& projectMSDLApp = dynamic_cast<ProjectMSDLApplication&>(app);
     _userConfig = projectMSDLApp.UserConfiguration();
-    _config = app.config().createView("window");
+    // Use the facade as the single read path so window settings stay key-consistent.
+    _configurationFacade = std::make_unique<ConfigurationFacade>(app.config(), *_userConfig);
 
     if (!_renderingWindow)
     {
@@ -76,10 +78,10 @@ void SDLRenderingWindow::Fullscreen()
 {
     SDL_GetWindowSize(_renderingWindow, &_lastWindowWidth, &_lastWindowHeight);
     SDL_ShowCursor(false);
-    if (_config->getBool("window.fullscreen.exclusiveMode", false))
+    if (_configurationFacade->window().fullscreenExclusiveMode())
     {
-        int fullscreenWidth = _config->getInt("window.fullscreen.width", 0);
-        int fullscreenHeight = _config->getInt("window.fullscreen.height", 0);
+        int fullscreenWidth = _configurationFacade->window().fullscreenWidth();
+        int fullscreenHeight = _configurationFacade->window().fullscreenHeight();
         if (fullscreenWidth > 0 && fullscreenHeight > 0)
         {
             SDL_RestoreWindow(_renderingWindow);
@@ -114,7 +116,7 @@ void SDLRenderingWindow::Fullscreen()
 void SDLRenderingWindow::Windowed()
 {
     SDL_SetWindowFullscreen(_renderingWindow, 0);
-    SDL_SetWindowBordered(_renderingWindow, _config->getBool("borderless", false) ? SDL_FALSE : SDL_TRUE);
+    SDL_SetWindowBordered(_renderingWindow, _configurationFacade->window().borderless() ? SDL_FALSE : SDL_TRUE);
     if (_lastWindowWidth > 0 && _lastWindowHeight > 0)
     {
         SDL_SetWindowSize(_renderingWindow, _lastWindowWidth, _lastWindowHeight);
@@ -198,11 +200,11 @@ void SDLRenderingWindow::CreateSDLWindow()
 {
     SDL_InitSubSystem(SDL_INIT_VIDEO);
 
-    int width{_config->getInt("width", 800)};
-    int height{_config->getInt("height", 600)};
-    int left{_config->getInt("left", 0)};
-    int top{_config->getInt("top", 0)};
-    bool positionOverridden = _config->getBool("overridePosition", false);
+    int width{_configurationFacade->window().width()};
+    int height{_configurationFacade->window().height()};
+    int left{_configurationFacade->window().left()};
+    int top{_configurationFacade->window().top()};
+    bool positionOverridden = _configurationFacade->window().overridePosition();
 
     if (!positionOverridden)
     {
@@ -210,7 +212,7 @@ void SDLRenderingWindow::CreateSDLWindow()
         top = SDL_WINDOWPOS_UNDEFINED;
     }
 
-    auto display = _config->getInt("monitor", 0);
+    auto display = _configurationFacade->window().monitor();
     if (display > 0)
     {
         poco_debug_f1(_logger, "User requested to place window on monitor %?d.", display);
@@ -220,6 +222,7 @@ void SDLRenderingWindow::CreateSDLWindow()
             display = numDisplays;
         }
 
+        // Stored monitor index is 1-based for config UX; SDL display index is 0-based.
         SDL_Rect bounds;
         SDL_GetDisplayBounds(display - 1, &bounds);
 
@@ -282,7 +285,7 @@ void SDLRenderingWindow::CreateSDLWindow()
     poco_debug_f1(_logger, "Initialized GLEW: %s", std::string(reinterpret_cast<const char*>(glewGetString(GLEW_VERSION))));
 #endif
 
-    if (_config->getBool("fullscreen", false))
+    if (_configurationFacade->window().fullscreen())
     {
         Fullscreen();
     }
@@ -391,7 +394,7 @@ void SDLRenderingWindow::UpdateWindowTitle()
 {
     std::string newTitle = "projectM";
 
-    if (_config->getBool("displayPresetNameInTitle", true))
+    if (_configurationFacade->window().displayPresetNameInTitle())
     {
         auto& app = Poco::Util::Application::instance();
         auto& projectMWrapper = app.getSubsystem<ProjectMWrapper>();
@@ -417,13 +420,13 @@ void SDLRenderingWindow::UpdateWindowTitle()
 
 void SDLRenderingWindow::UpdateSwapInterval()
 {
-    if (!_config->getBool("waitForVerticalSync", true))
+    if (!_configurationFacade->window().waitForVerticalSync())
     {
         SDL_GL_SetSwapInterval(0);
         return;
     }
 
-    if (_config->getBool("adaptiveVerticalSync", true))
+    if (_configurationFacade->window().adaptiveVerticalSync())
     {
         if (SDL_GL_SetSwapInterval(-1) == 0)
         {
@@ -446,17 +449,19 @@ void SDLRenderingWindow::OnConfigurationPropertyRemoved(const std::string& key)
         return;
     }
 
-    if (key == "window.waitForVerticalSync" || key == "window.adaptiveVerticalSync")
+    // Re-evaluate dependent runtime state when either VSync control key changes.
+    if (key == SettingsConfigKeys::kConfigWindowWaitForVerticalSync ||
+        key == SettingsConfigKeys::kConfigWindowAdaptiveVerticalSync)
     {
         UpdateSwapInterval();
     }
 
-    if (key == "window.borderless")
+    if (key == SettingsConfigKeys::kConfigWindowBorderless)
     {
-        SDL_SetWindowBordered(_renderingWindow, _config->getBool("borderless", false) ? SDL_FALSE : SDL_TRUE);
+        SDL_SetWindowBordered(_renderingWindow, _configurationFacade->window().borderless() ? SDL_FALSE : SDL_TRUE);
     }
 
-    if (key == "window.displayPresetNameInTitle")
+    if (key == SettingsConfigKeys::kConfigWindowDisplayPresetNameInTitle)
     {
         UpdateWindowTitle();
     }

--- a/src/SDLRenderingWindow.h
+++ b/src/SDLRenderingWindow.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include "config/ConfigurationFacade.h"
 #include "notifications/UpdateWindowTitleNotification.h"
+
+#include <memory>
 
 #include <SDL2/SDL.h>
 
@@ -142,7 +145,7 @@ protected:
     void OnConfigurationPropertyRemoved(const std::string& key);
 
     Poco::AutoPtr<Poco::Util::AbstractConfiguration> _userConfig; //!< View of the "projectM" configuration subkey in the "user" configuration.
-    Poco::AutoPtr<Poco::Util::AbstractConfiguration> _config; //!< View of the "window" configuration subkey.
+    std::unique_ptr<ConfigurationFacade> _configurationFacade; //!< Typed access to effective and persisted configuration.
 
     SDL_Window* _renderingWindow{ nullptr }; //!< Pointer to the SDL window used for rendering.
     SDL_GLContext _glContext{ nullptr }; //!< Pointer to the OpenGL context associated with the window.

--- a/src/config/ConfigurationFacade.cpp
+++ b/src/config/ConfigurationFacade.cpp
@@ -4,7 +4,22 @@
 
 namespace
 {
-// Keep behavior aligned with existing UI defaults when key is absent.
+// _effectiveConfig resolves defaults plus runtime overrides (user file, CLI, etc.).
+// _userConfig is the persisted write layer used by mutating facade methods.
+// Constants below preserve established behavior when a key is absent from effective config.
+constexpr int kWindowWidthDefault = 800;
+constexpr int kWindowHeightDefault = 600;
+constexpr int kWindowLeftDefault = 0;
+constexpr int kWindowTopDefault = 0;
+constexpr bool kWindowOverridePositionDefault = false;
+constexpr int kWindowMonitorDefault = 0;
+constexpr bool kWindowBorderlessDefault = false;
+constexpr bool kWindowFullscreenDefault = false;
+constexpr bool kWindowFullscreenExclusiveModeDefault = false;
+constexpr int kWindowFullscreenWidthDefault = 0;
+constexpr int kWindowFullscreenHeightDefault = 0;
+constexpr bool kWindowWaitForVerticalSyncDefault = true;
+constexpr bool kWindowAdaptiveVerticalSyncDefault = true;
 constexpr bool kDisplayPresetNameInTitleDefault = true;
 } // namespace
 
@@ -15,9 +30,93 @@ ConfigurationFacade::WindowConfigFacade::WindowConfigFacade(Poco::Util::Abstract
 {
 }
 
+int ConfigurationFacade::WindowConfigFacade::width() const
+{
+    // Read resolved startup window width from effective configuration.
+    return _effectiveConfig.getInt(SettingsConfigKeys::kConfigWindowWidth, kWindowWidthDefault);
+}
+
+int ConfigurationFacade::WindowConfigFacade::height() const
+{
+    // Read resolved startup window height from effective configuration.
+    return _effectiveConfig.getInt(SettingsConfigKeys::kConfigWindowHeight, kWindowHeightDefault);
+}
+
+int ConfigurationFacade::WindowConfigFacade::left() const
+{
+    // Read startup X position (monitor-relative when override is enabled).
+    return _effectiveConfig.getInt(SettingsConfigKeys::kConfigWindowLeft, kWindowLeftDefault);
+}
+
+int ConfigurationFacade::WindowConfigFacade::top() const
+{
+    // Read startup Y position (monitor-relative when override is enabled).
+    return _effectiveConfig.getInt(SettingsConfigKeys::kConfigWindowTop, kWindowTopDefault);
+}
+
+bool ConfigurationFacade::WindowConfigFacade::overridePosition() const
+{
+    // Read whether explicit startup position values should be applied.
+    return _effectiveConfig.getBool(SettingsConfigKeys::kConfigWindowOverridePosition,
+                                    kWindowOverridePositionDefault);
+}
+
+int ConfigurationFacade::WindowConfigFacade::monitor() const
+{
+    // Read preferred startup monitor index (0 means OS-selected display).
+    return _effectiveConfig.getInt(SettingsConfigKeys::kConfigWindowMonitor, kWindowMonitorDefault);
+}
+
+bool ConfigurationFacade::WindowConfigFacade::borderless() const
+{
+    // Read whether the window should start with OS border/title decorations disabled.
+    return _effectiveConfig.getBool(SettingsConfigKeys::kConfigWindowBorderless, kWindowBorderlessDefault);
+}
+
+bool ConfigurationFacade::WindowConfigFacade::fullscreen() const
+{
+    // Read whether startup should enter fullscreen mode.
+    return _effectiveConfig.getBool(SettingsConfigKeys::kConfigWindowFullscreen, kWindowFullscreenDefault);
+}
+
+bool ConfigurationFacade::WindowConfigFacade::fullscreenExclusiveMode() const
+{
+    // Read whether fullscreen should use exclusive display mode.
+    return _effectiveConfig.getBool(SettingsConfigKeys::kConfigWindowFullscreenExclusive,
+                                    kWindowFullscreenExclusiveModeDefault);
+}
+
+int ConfigurationFacade::WindowConfigFacade::fullscreenWidth() const
+{
+    // Read exclusive fullscreen target width.
+    return _effectiveConfig.getInt(SettingsConfigKeys::kConfigFullscreenWidth,
+                                   kWindowFullscreenWidthDefault);
+}
+
+int ConfigurationFacade::WindowConfigFacade::fullscreenHeight() const
+{
+    // Read exclusive fullscreen target height.
+    return _effectiveConfig.getInt(SettingsConfigKeys::kConfigFullscreenHeight,
+                                   kWindowFullscreenHeightDefault);
+}
+
+bool ConfigurationFacade::WindowConfigFacade::waitForVerticalSync() const
+{
+    // Read whether frame presentation should block on VSync.
+    return _effectiveConfig.getBool(SettingsConfigKeys::kConfigWindowWaitForVerticalSync,
+                                    kWindowWaitForVerticalSyncDefault);
+}
+
+bool ConfigurationFacade::WindowConfigFacade::adaptiveVerticalSync() const
+{
+    // Read whether adaptive VSync should be attempted when VSync is enabled.
+    return _effectiveConfig.getBool(SettingsConfigKeys::kConfigWindowAdaptiveVerticalSync,
+                                    kWindowAdaptiveVerticalSyncDefault);
+}
+
 bool ConfigurationFacade::WindowConfigFacade::displayPresetNameInTitle() const
 {
-    // Read from effective config so defaults and user overrides are both respected.
+    // Read whether preset names should be appended to the window title.
     return _effectiveConfig.getBool(SettingsConfigKeys::kConfigWindowDisplayPresetNameInTitle,
                                     kDisplayPresetNameInTitleDefault);
 }

--- a/src/config/ConfigurationFacade.h
+++ b/src/config/ConfigurationFacade.h
@@ -5,17 +5,116 @@
 class ConfigurationFacade
 {
 public:
-    // Window-scoped settings read from the effective (merged) config and persist into user config.
+    /**
+     * @brief Facade for window-scoped configuration access.
+     *
+     * Reads values from the effective (merged) configuration and persists writable values
+     * to the user configuration layer.
+     */
     class WindowConfigFacade
     {
     public:
+        /**
+         * @brief Creates a facade for window configuration values.
+         * @param effectiveConfig The merged read configuration source.
+         * @param userConfig The writable user configuration source.
+         */
         WindowConfigFacade(Poco::Util::AbstractConfiguration& effectiveConfig,
                            Poco::Util::AbstractConfiguration& userConfig);
 
+        /**
+         * @brief Returns the configured startup window width.
+         * @return Startup width in pixels.
+         */
+        int width() const;
+
+        /**
+         * @brief Returns the configured startup window height.
+         * @return Startup height in pixels.
+         */
+        int height() const;
+
+        /**
+         * @brief Returns the configured startup X position.
+         * @return Startup left position.
+         */
+        int left() const;
+
+        /**
+         * @brief Returns the configured startup Y position.
+         * @return Startup top position.
+         */
+        int top() const;
+
+        /**
+         * @brief Returns whether startup position override is enabled.
+         * @return True if startup position values should be applied.
+         */
+        bool overridePosition() const;
+
+        /**
+         * @brief Returns the configured startup monitor.
+         * @return Monitor index where 0 means OS-selected display.
+         */
+        int monitor() const;
+
+        /**
+         * @brief Returns whether the window should be borderless.
+         * @return True if borderless startup is enabled.
+         */
+        bool borderless() const;
+
+        /**
+         * @brief Returns whether startup fullscreen mode is enabled.
+         * @return True if window should start in fullscreen.
+         */
+        bool fullscreen() const;
+
+        /**
+         * @brief Returns whether exclusive fullscreen mode is enabled.
+         * @return True if exclusive fullscreen should be used.
+         */
+        bool fullscreenExclusiveMode() const;
+
+        /**
+         * @brief Returns the configured exclusive fullscreen width.
+         * @return Fullscreen width in pixels.
+         */
+        int fullscreenWidth() const;
+
+        /**
+         * @brief Returns the configured exclusive fullscreen height.
+         * @return Fullscreen height in pixels.
+         */
+        int fullscreenHeight() const;
+
+        /**
+         * @brief Returns whether waiting for vertical sync is enabled.
+         * @return True if VSync wait is enabled.
+         */
+        bool waitForVerticalSync() const;
+
+        /**
+         * @brief Returns whether adaptive vertical sync is enabled.
+         * @return True if adaptive VSync is enabled.
+         */
+        bool adaptiveVerticalSync() const;
+
+        /**
+         * @brief Returns whether preset names are shown in the window title.
+         * @return True if preset names should be appended to the title.
+         */
         bool displayPresetNameInTitle() const;
 
+        /**
+         * @brief Sets whether preset names are shown in the window title.
+         * @param enabled True to append preset names to the title.
+         */
         void setDisplayPresetNameInTitle(bool enabled);
 
+        /**
+         * @brief Toggles preset-name display in the window title.
+         */
         void toggleDisplayPresetNameInTitle();
 
     private:
@@ -25,10 +124,17 @@ public:
         Poco::Util::AbstractConfiguration& _userConfig;
     };
 
-    // Placeholder facade for projectM-scoped settings methods.
+    /**
+     * @brief Placeholder facade for projectM-scoped settings.
+     */
     class ProjectMConfigFacade
     {
     public:
+        /**
+         * @brief Creates a facade for projectM-scoped configuration values.
+         * @param effectiveConfig The merged read configuration source.
+         * @param userConfig The writable user configuration source.
+         */
         ProjectMConfigFacade(Poco::Util::AbstractConfiguration& effectiveConfig,
                              Poco::Util::AbstractConfiguration& userConfig);
 
@@ -37,10 +143,17 @@ public:
         Poco::Util::AbstractConfiguration& _userConfig;
     };
 
-    // Placeholder facade for audio-scoped settings methods.
+    /**
+     * @brief Placeholder facade for audio-scoped settings.
+     */
     class AudioConfigFacade
     {
     public:
+        /**
+         * @brief Creates a facade for audio-scoped configuration values.
+         * @param effectiveConfig The merged read configuration source.
+         * @param userConfig The writable user configuration source.
+         */
         AudioConfigFacade(Poco::Util::AbstractConfiguration& effectiveConfig,
                           Poco::Util::AbstractConfiguration& userConfig);
 
@@ -49,14 +162,30 @@ public:
         Poco::Util::AbstractConfiguration& _userConfig;
     };
 
+    /**
+     * @brief Creates the top-level configuration facade.
+     * @param effectiveConfig The merged read configuration source.
+     * @param userConfig The writable user configuration source.
+     */
     ConfigurationFacade(Poco::Util::AbstractConfiguration& effectiveConfig,
                         Poco::Util::AbstractConfiguration& userConfig);
 
-    // Accessors expose scoped config APIs and hide string-key usage.
+    /**
+     * @brief Returns the window-scoped configuration facade.
+     * @return The window facade.
+     */
     WindowConfigFacade& window();
 
+    /**
+     * @brief Returns the projectM-scoped configuration facade.
+     * @return The projectM facade.
+     */
     ProjectMConfigFacade& projectM();
 
+    /**
+     * @brief Returns the audio-scoped configuration facade.
+     * @return The audio facade.
+     */
     AudioConfigFacade& audio();
 
 private:


### PR DESCRIPTION
Closes #52

### Summary
Refactored window configuration usage in `SDLRenderingWindow` to remove mixed view-relative and fully-qualified key access. Expanded `ConfigurationFacade::WindowConfigFacade` and migrated call sites so window settings are consumed through typed facade methods.

Key updates:
- Added typed window getters in `src/config/ConfigurationFacade.h` / `src/config/ConfigurationFacade.cpp` for:
  - startup size/position/monitor
  - fullscreen mode and exclusive resolution
  - VSync and adaptive VSync
  - window-title preset display
- Migrated `src/SDLRenderingWindow.cpp` to use `ConfigurationFacade.window()` for reads.
- Replaced raw key-string comparisons in window property-change handlers with canonical `SettingsConfigKeys` constants.
- Added Doxygen-style method documentation for `ConfigurationFacade` methods.

### Design Pattern
- Pattern used: **Facade**
- Category: **Structural**
- Why: `ConfigurationFacade::WindowConfigFacade` provides a single typed interface for window config behavior, hiding key-string details and merged-config access from runtime window code.

### Verification
- Build verified successfully:
  - `cmake --build build`
- Tests verified successfully:
  - `ctest --test-dir build --output-on-failure -R "projectMSDL-renderer-test|projectMSDL-ui-test"`
  - Result: 2/2 passed
- Manual verification: App runs normally and window settings save/reset as expected

### Evidence
- `src/config/ConfigurationFacade.h` and `src/config/ConfigurationFacade.cpp` now expose and implement typed window config accessors.
- `src/SDLRenderingWindow.cpp` now reads window/fullscreen/VSync/title settings through the facade.
- `src/SDLRenderingWindow.cpp` property-change handling now uses canonical constants instead of raw literals for window keys.
- `src/SDLRenderingWindow.h` now holds a `ConfigurationFacade` instance for typed config access.
