### PR TITLE
630:P3 Refactor projectM config usage through facade

### DIFF
--- a/.github/workflows/buildcheck.yaml
+++ b/.github/workflows/buildcheck.yaml
@@ -205,14 +205,14 @@ jobs:
       - name: Build/Install libprojectM
         run: |
           mkdir cmake-build-libprojectm
-          cmake -G "Visual Studio 17 2022" -A "X64" -S "${{ github.workspace }}/projectm" -B "${{ github.workspace }}/cmake-build-libprojectm" -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows-static -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install-libprojectm" -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded$<$<CONFIG:Debug>:Debug>" -DCMAKE_VERBOSE_MAKEFILE=YES -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=NO
+          cmake -G "Visual Studio 18 2026" -A "X64" -S "${{ github.workspace }}/projectm" -B "${{ github.workspace }}/cmake-build-libprojectm" -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows-static -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install-libprojectm" -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded$<$<CONFIG:Debug>:Debug>" -DCMAKE_VERBOSE_MAKEFILE=YES -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=NO
           cmake --build "${{ github.workspace }}/cmake-build-libprojectm" --config Release --parallel
           cmake --install "${{ github.workspace }}/cmake-build-libprojectm" --config Release
 
       - name: Build projectMSDL
         run: |
           mkdir cmake-build-frontend-sdl2
-          cmake -G "Visual Studio 17 2022" -A "X64" -S "${{ github.workspace }}/frontend-sdl2" -B "${{ github.workspace }}/cmake-build-frontend-sdl2" -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows-static  -DCMAKE_PREFIX_PATH="${{ github.workspace }}/install-libprojectm" -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install-frontend-sdl2" -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded$<$<CONFIG:Debug>:Debug>" -DCMAKE_VERBOSE_MAKEFILE=YES -DSDL2_LINKAGE=static -DBUILD_TESTING=YES
+          cmake -G "Visual Studio 18 2026" -A "X64" -S "${{ github.workspace }}/frontend-sdl2" -B "${{ github.workspace }}/cmake-build-frontend-sdl2" -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows-static  -DCMAKE_PREFIX_PATH="${{ github.workspace }}/install-libprojectm" -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/install-frontend-sdl2" -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded$<$<CONFIG:Debug>:Debug>" -DCMAKE_VERBOSE_MAKEFILE=YES -DSDL2_LINKAGE=static -DBUILD_TESTING=YES
           cmake --build "${{ github.workspace }}/cmake-build-frontend-sdl2" --parallel --config Release
 
       - name: Package projectMSDL

--- a/src/ProjectMWrapper.cpp
+++ b/src/ProjectMWrapper.cpp
@@ -3,6 +3,9 @@
 #include "ProjectMSDLApplication.h"
 #include "SDLRenderingWindow.h"
 
+#include "config/ConfigurationFacade.h"
+#include "config/SettingsConfigKeys.h"
+
 #include "notifications/DisplayToastNotification.h"
 
 #include <Poco/Delegate.h>
@@ -42,6 +45,7 @@ void ProjectMWrapper::initialize(Poco::Util::Application& app)
 void ProjectMWrapper::InitializeConfiguration(Poco::Util::Application& app)
 {
     auto& projectMSDLApp = dynamic_cast<ProjectMSDLApplication&>(app);
+    _effectiveConfig = &projectMSDLApp.config();
     _projectMConfigView = projectMSDLApp.config().createView("projectM");
     _userConfig = projectMSDLApp.UserConfiguration();
     poco_information_f1(_logger, "Events enabled: %?d", _projectMConfigView->eventsEnabled());
@@ -67,6 +71,8 @@ void ProjectMWrapper::InitializeProjectMCore(Poco::Util::Application& app)
 
 void ProjectMWrapper::ConfigureProjectMSettings()
 {
+    ConfigurationFacade configurationFacade(*_effectiveConfig, *_userConfig);
+
     // Set window dimensions
     projectm_set_window_size(_projectM, _initCanvasWidth, _initCanvasHeight);
 
@@ -84,7 +90,7 @@ void ProjectMWrapper::ConfigureProjectMSettings()
 
     // Configure aspect and preset behavior
     projectm_set_aspect_correction(_projectM, _projectMConfigView->getBool("aspectCorrectionEnabled", true));
-    projectm_set_preset_locked(_projectM, _projectMConfigView->getBool("presetLocked", false));
+    projectm_set_preset_locked(_projectM, configurationFacade.projectM().presetLocked());
 
     // Configure preset display settings
     projectm_set_preset_duration(_projectM, _projectMConfigView->getDouble("displayDuration", 30.0));
@@ -92,7 +98,7 @@ void ProjectMWrapper::ConfigureProjectMSettings()
     projectm_set_hard_cut_enabled(_projectM, _projectMConfigView->getBool("hardCutsEnabled", false));
     projectm_set_hard_cut_duration(_projectM, _projectMConfigView->getDouble("hardCutDuration", 20.0));
     projectm_set_hard_cut_sensitivity(_projectM, static_cast<float>(_projectMConfigView->getDouble("hardCutSensitivity", 1.0)));
-    projectm_set_beat_sensitivity(_projectM, static_cast<float>(_projectMConfigView->getDouble("beatSensitivity", 1.0)));
+    projectm_set_beat_sensitivity(_projectM, static_cast<float>(configurationFacade.projectM().beatSensitivity()));
 
     // Configure texture paths if available
     if (!_initTexturePaths.empty())
@@ -109,6 +115,8 @@ void ProjectMWrapper::ConfigureProjectMSettings()
 
 void ProjectMWrapper::InitializePlaylist()
 {
+    ConfigurationFacade configurationFacade(*_effectiveConfig, *_userConfig);
+
     // Create playlist manager
     _playlist = projectm_playlist_create(_projectM);
     if (!_playlist)
@@ -118,7 +126,7 @@ void ProjectMWrapper::InitializePlaylist()
     }
 
     // Configure shuffle mode
-    projectm_playlist_set_shuffle(_playlist, _projectMConfigView->getBool("shuffleEnabled", true));
+    projectm_playlist_set_shuffle(_playlist, configurationFacade.projectM().shuffleEnabled());
 
     // Populate playlist from preset paths
     for (const auto& presetPath : _initPresetPaths)
@@ -211,9 +219,11 @@ void ProjectMWrapper::RenderFrame() const
 
 void ProjectMWrapper::DisplayInitialPreset()
 {
+    ConfigurationFacade configurationFacade(*_effectiveConfig, *_userConfig);
+
     if (!_projectMConfigView->getBool("enableSplash", true))
     {
-        if (_projectMConfigView->getBool("shuffleEnabled", true))
+        if (configurationFacade.projectM().shuffleEnabled())
         {
             projectm_playlist_play_next(_playlist, true);
         }
@@ -264,6 +274,7 @@ void ProjectMWrapper::PresetSwitchedEvent(bool isHardCut, unsigned int index, vo
 
 void ProjectMWrapper::PlaybackControlNotificationHandler(const Poco::AutoPtr<PlaybackControlNotification>& notification)
 {
+    ConfigurationFacade configurationFacade(*_effectiveConfig, *_userConfig);
     bool shuffleEnabled = projectm_playlist_get_shuffle(_playlist);
 
     switch (notification->ControlAction())
@@ -292,11 +303,11 @@ void ProjectMWrapper::PlaybackControlNotificationHandler(const Poco::AutoPtr<Pla
         }
 
         case PlaybackControlNotification::Action::ToggleShuffle:
-            _userConfig->setBool("projectM.shuffleEnabled", !shuffleEnabled);
+            configurationFacade.projectM().setShuffleEnabled(!shuffleEnabled);
             break;
 
         case PlaybackControlNotification::Action::TogglePresetLocked: {
-            _userConfig->setBool("projectM.presetLocked", !projectm_get_preset_locked(_projectM));
+            configurationFacade.projectM().setPresetLocked(!projectm_get_preset_locked(_projectM));
             break;
         }
     }
@@ -337,48 +348,55 @@ void ProjectMWrapper::OnConfigurationPropertyRemoved(const std::string& key)
         return;
     }
 
-    if (key == "projectM.presetLocked")
+    ConfigurationFacade configurationFacade(*_effectiveConfig, *_userConfig);
+
+    if (key == SettingsConfigKeys::kConfigProjectMPresetLocked)
     {
-        projectm_set_preset_locked(_projectM, _projectMConfigView->getBool("presetLocked", false));
+        projectm_set_preset_locked(_projectM, configurationFacade.projectM().presetLocked());
         Poco::NotificationCenter::defaultCenter().postNotification(new UpdateWindowTitleNotification);
     }
 
-    if (key == "projectM.shuffleEnabled")
+    if (key == SettingsConfigKeys::kConfigProjectMShuffleEnabled)
     {
-        projectm_playlist_set_shuffle(_playlist, _projectMConfigView->getBool("shuffleEnabled", true));
+        projectm_playlist_set_shuffle(_playlist, configurationFacade.projectM().shuffleEnabled());
     }
 
-    if (key == "projectM.aspectCorrectionEnabled")
+    if (key == SettingsConfigKeys::kConfigProjectMBeatSensitivity)
+    {
+        projectm_set_beat_sensitivity(_projectM, static_cast<float>(configurationFacade.projectM().beatSensitivity()));
+    }
+
+    if (key == SettingsConfigKeys::kConfigProjectMAspectCorrectionEnabled)
     {
         projectm_set_aspect_correction(_projectM, _projectMConfigView->getBool("aspectCorrectionEnabled", true));
     }
 
-    if (key == "projectM.displayDuration")
+    if (key == SettingsConfigKeys::kConfigProjectMDisplayDuration)
     {
         projectm_set_preset_duration(_projectM, _projectMConfigView->getDouble("displayDuration", 30.0));
     }
 
-    if (key == "projectM.transitionDuration")
+    if (key == SettingsConfigKeys::kConfigProjectMTransitionDuration)
     {
         projectm_set_soft_cut_duration(_projectM, _projectMConfigView->getDouble("transitionDuration", 3.0));
     }
 
-    if (key == "projectM.hardCutsEnabled")
+    if (key == SettingsConfigKeys::kConfigProjectMHardCutsEnabled)
     {
         projectm_set_aspect_correction(_projectM, _projectMConfigView->getBool("hardCutsEnabled", false));
     }
 
-    if (key == "projectM.hardCutDuration")
+    if (key == SettingsConfigKeys::kConfigProjectMHardCutDuration)
     {
         projectm_set_hard_cut_duration(_projectM, _projectMConfigView->getDouble("hardCutDuration", 20.0));
     }
 
-    if (key == "projectM.hardCutSensitivity")
+    if (key == SettingsConfigKeys::kConfigProjectMHardCutSensitivity)
     {
         projectm_set_hard_cut_sensitivity(_projectM, static_cast<float>(_projectMConfigView->getDouble("hardCutSensitivity", 1.0)));
     }
 
-    if (key == "projectM.meshX" || key == "projectM.meshY")
+    if (key == SettingsConfigKeys::kConfigProjectMMeshX || key == SettingsConfigKeys::kConfigProjectMMeshY)
     {
         projectm_set_mesh_size(_projectM, _projectMConfigView->getUInt64("meshX", 48), _projectMConfigView->getUInt64("meshY", 32));
     }

--- a/src/ProjectMWrapper.h
+++ b/src/ProjectMWrapper.h
@@ -138,6 +138,7 @@ private:
     std::vector<std::string> _initPresetPaths;
     std::vector<std::string> _initTexturePaths;
 
+    Poco::Util::AbstractConfiguration* _effectiveConfig{nullptr}; //!< Effective merged configuration root used for facade reads.
     Poco::AutoPtr<Poco::Util::AbstractConfiguration> _userConfig; //!< View of the "projectM" configuration subkey in the "user" configuration.
     Poco::AutoPtr<Poco::Util::AbstractConfiguration> _projectMConfigView; //!< View of the "projectM" configuration subkey in the "effective" configuration.
 

--- a/src/config/ConfigurationFacade.cpp
+++ b/src/config/ConfigurationFacade.cpp
@@ -21,8 +21,13 @@ constexpr int kWindowFullscreenHeightDefault = 0;
 constexpr bool kWindowWaitForVerticalSyncDefault = true;
 constexpr bool kWindowAdaptiveVerticalSyncDefault = true;
 constexpr bool kDisplayPresetNameInTitleDefault = true;
+constexpr bool kProjectMPresetLockedDefault = false;
+constexpr bool kProjectMShuffleEnabledDefault = true;
+constexpr bool kProjectMDisplayToastsDefault = true;
+constexpr double kProjectMBeatSensitivityDefault = 1.0;
 } // namespace
 
+// WindowConfigFacade implementation
 ConfigurationFacade::WindowConfigFacade::WindowConfigFacade(Poco::Util::AbstractConfiguration& effectiveConfig,
                                                             Poco::Util::AbstractConfiguration& userConfig)
     : _effectiveConfig(effectiveConfig)
@@ -133,6 +138,7 @@ void ConfigurationFacade::WindowConfigFacade::toggleDisplayPresetNameInTitle()
     setDisplayPresetNameInTitle(!displayPresetNameInTitle());
 }
 
+// ProjectMConfigFacade implementation
 ConfigurationFacade::ProjectMConfigFacade::ProjectMConfigFacade(Poco::Util::AbstractConfiguration& effectiveConfig,
                                                                 Poco::Util::AbstractConfiguration& userConfig)
     : _effectiveConfig(effectiveConfig)
@@ -140,6 +146,77 @@ ConfigurationFacade::ProjectMConfigFacade::ProjectMConfigFacade(Poco::Util::Abst
 {
 }
 
+bool ConfigurationFacade::ProjectMConfigFacade::presetLocked() const
+{
+    // Read whether preset locking is enabled for playback.
+    return _effectiveConfig.getBool(SettingsConfigKeys::kConfigProjectMPresetLocked,
+                                    kProjectMPresetLockedDefault);
+}
+
+void ConfigurationFacade::ProjectMConfigFacade::setPresetLocked(bool enabled)
+{
+    // Persist explicit preset lock choice in the user configuration layer.
+    _userConfig.setBool(SettingsConfigKeys::kConfigProjectMPresetLocked, enabled);
+}
+
+void ConfigurationFacade::ProjectMConfigFacade::togglePresetLocked()
+{
+    // Toggle based on the resolved value currently visible to the UI.
+    setPresetLocked(!presetLocked());
+}
+
+bool ConfigurationFacade::ProjectMConfigFacade::shuffleEnabled() const
+{
+    // Read whether shuffle mode is enabled for preset playback.
+    return _effectiveConfig.getBool(SettingsConfigKeys::kConfigProjectMShuffleEnabled,
+                                    kProjectMShuffleEnabledDefault);
+}
+
+void ConfigurationFacade::ProjectMConfigFacade::setShuffleEnabled(bool enabled)
+{
+    // Persist explicit shuffle mode choice in the user configuration layer.
+    _userConfig.setBool(SettingsConfigKeys::kConfigProjectMShuffleEnabled, enabled);
+}
+
+void ConfigurationFacade::ProjectMConfigFacade::toggleShuffleEnabled()
+{
+    // Toggle based on the resolved value currently visible to the UI.
+    setShuffleEnabled(!shuffleEnabled());
+}
+
+bool ConfigurationFacade::ProjectMConfigFacade::displayToasts() const
+{
+    // Read whether on-screen toast messages should be displayed.
+    return _effectiveConfig.getBool(SettingsConfigKeys::kConfigProjectMDisplayToasts,
+                                    kProjectMDisplayToastsDefault);
+}
+
+void ConfigurationFacade::ProjectMConfigFacade::setDisplayToasts(bool enabled)
+{
+    // Persist explicit toast display choice in the user configuration layer.
+    _userConfig.setBool(SettingsConfigKeys::kConfigProjectMDisplayToasts, enabled);
+}
+
+void ConfigurationFacade::ProjectMConfigFacade::toggleDisplayToasts()
+{
+    // Toggle based on the resolved value currently visible to the UI.
+    setDisplayToasts(!displayToasts());
+}
+
+double ConfigurationFacade::ProjectMConfigFacade::beatSensitivity() const
+{
+    // Read the configured beat sensitivity scalar used by projectM.
+    return _effectiveConfig.getDouble(SettingsConfigKeys::kConfigProjectMBeatSensitivity,
+                                      kProjectMBeatSensitivityDefault);
+}
+
+void ConfigurationFacade::ProjectMConfigFacade::setBeatSensitivity(double value)
+{
+    // Persist explicit beat sensitivity choice in the user configuration layer.
+    _userConfig.setDouble(SettingsConfigKeys::kConfigProjectMBeatSensitivity, value);
+}
+
+// AudioConfigFacade implementation
 ConfigurationFacade::AudioConfigFacade::AudioConfigFacade(Poco::Util::AbstractConfiguration& effectiveConfig,
                                                           Poco::Util::AbstractConfiguration& userConfig)
     : _effectiveConfig(effectiveConfig)
@@ -147,6 +224,8 @@ ConfigurationFacade::AudioConfigFacade::AudioConfigFacade(Poco::Util::AbstractCo
 {
 }
 
+
+// ConfigurationFacade implementation
 ConfigurationFacade::ConfigurationFacade(Poco::Util::AbstractConfiguration& effectiveConfig,
                                          Poco::Util::AbstractConfiguration& userConfig)
     // Each scoped facade shares the same read/write configuration sources.

--- a/src/config/ConfigurationFacade.h
+++ b/src/config/ConfigurationFacade.h
@@ -138,6 +138,69 @@ public:
         ProjectMConfigFacade(Poco::Util::AbstractConfiguration& effectiveConfig,
                              Poco::Util::AbstractConfiguration& userConfig);
 
+        /**
+         * @brief Returns whether the current preset is locked.
+         * @return True if preset locking is enabled.
+         */
+        bool presetLocked() const;
+
+        /**
+         * @brief Sets preset lock state.
+         * @param enabled True to lock the current preset.
+         */
+        void setPresetLocked(bool enabled);
+
+        /**
+         * @brief Toggles preset lock state.
+         */
+        void togglePresetLocked();
+
+        /**
+         * @brief Returns whether shuffle is enabled for preset playback.
+         * @return True if shuffle mode is enabled.
+         */
+        bool shuffleEnabled() const;
+
+        /**
+         * @brief Sets shuffle state.
+         * @param enabled True to enable shuffle mode.
+         */
+        void setShuffleEnabled(bool enabled);
+
+        /**
+         * @brief Toggles shuffle state.
+         */
+        void toggleShuffleEnabled();
+
+        /**
+         * @brief Returns whether toast messages are displayed.
+         * @return True if toast display is enabled.
+         */
+        bool displayToasts() const;
+
+        /**
+         * @brief Sets whether toast messages are displayed.
+         * @param enabled True to enable toast display.
+         */
+        void setDisplayToasts(bool enabled);
+
+        /**
+         * @brief Toggles toast message display.
+         */
+        void toggleDisplayToasts();
+
+        /**
+         * @brief Returns the configured beat sensitivity value.
+         * @return Beat sensitivity scalar.
+         */
+        double beatSensitivity() const;
+
+        /**
+         * @brief Sets beat sensitivity.
+         * @param value Beat sensitivity scalar.
+         */
+        void setBeatSensitivity(double value);
+
     private:
         Poco::Util::AbstractConfiguration& _effectiveConfig;
         Poco::Util::AbstractConfiguration& _userConfig;

--- a/src/gui/MainMenu.cpp
+++ b/src/gui/MainMenu.cpp
@@ -62,6 +62,7 @@ void MainMenu::DrawPlaybackMenu()
     if (!ImGui::BeginMenu("Playback")) return;
 
     auto& app = ProjectMSDLApplication::instance();
+    ConfigurationFacade configurationFacade(app.config(), *app.UserConfiguration());
 
     if (ImGui::MenuItem("Play Next Preset", "n")) 
     {
@@ -82,11 +83,11 @@ void MainMenu::DrawPlaybackMenu()
 
     ImGui::Separator();
 
-    if (ImGui::MenuItem("Lock Preset", "Spacebar", app.config().getBool("projectM.presetLocked", false)))
+    if (ImGui::MenuItem("Lock Preset", "Spacebar", configurationFacade.projectM().presetLocked()))
     {
         PostPlaybackAction(static_cast<int>(PlaybackControlNotification::Action::TogglePresetLocked));
     }
-    if (ImGui::MenuItem("Enable Shuffle", "y", app.config().getBool("projectM.shuffleEnabled", true)))
+    if (ImGui::MenuItem("Enable Shuffle", "y", configurationFacade.projectM().shuffleEnabled()))
     {
         PostPlaybackAction(static_cast<int>(PlaybackControlNotification::Action::ToggleShuffle));
     }
@@ -116,9 +117,9 @@ void MainMenu::DrawOptionsMenu()
 
     ImGui::Separator();
 
-    if (ImGui::MenuItem("Display Toast Messages", "", app.config().getBool("projectM.displayToasts", true)))
+    if (ImGui::MenuItem("Display Toast Messages", "", configurationFacade.projectM().displayToasts()))
     {
-        ToggleUserConfig("projectM.displayToasts", true);
+        configurationFacade.projectM().toggleDisplayToasts();
     }
     if (ImGui::MenuItem("Display Preset Name in Window Title", "", configurationFacade.window().displayPresetNameInTitle()))
     {
@@ -133,7 +134,7 @@ void MainMenu::DrawOptionsMenu()
     if (ImGui::SliderFloat("Beat Sensitivity", &beatSensitivity, 0.0f, 2.0f))
     {
         projectm_set_beat_sensitivity(_projectMWrapper.ProjectM(), beatSensitivity);
-        app.UserConfiguration()->setDouble("projectM.beatSensitivity", beatSensitivity);
+        configurationFacade.projectM().setBeatSensitivity(beatSensitivity);
     }
 
     ImGui::EndMenu();
@@ -201,12 +202,6 @@ void MainMenu::PostPlaybackAction(int action)
 {
     _notificationCenter.postNotification(
         new PlaybackControlNotification(static_cast<PlaybackControlNotification::Action>(action)));
-}
-
-void MainMenu::ToggleUserConfig(const std::string& key, bool defaultValue) const 
-{
-    auto& app = ProjectMSDLApplication::instance();
-    app.UserConfiguration()->setBool(key, !app.config().getBool(key, defaultValue));
 }
 
 void MainMenu::OpenExternalUrl(const char* url) const 

--- a/src/gui/MainMenu.h
+++ b/src/gui/MainMenu.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <string>
-
 class ProjectMGUI;
 class ProjectMWrapper;
 class AudioCapture;
@@ -35,6 +33,5 @@ private:
     void DrawHelpMenu();
 
     void PostPlaybackAction(int action);
-    void ToggleUserConfig(const std::string& key, bool defaultValue) const;
     void OpenExternalUrl(const char* url) const;
 };


### PR DESCRIPTION
Closes #53

## Summary of Changes
- Expanded `ConfigurationFacade::ProjectMConfigFacade` with typed projectM methods for `presetLocked`, `shuffleEnabled`, `displayToasts`, and `beatSensitivity` (including write/toggle methods where applicable).
- Migrated `MainMenu` projectM pathways to typed facade access:
  - Playback menu state reads for Lock Preset and Enable Shuffle.
  - Options menu toggle for Display Toast Messages.
  - Beat Sensitivity persistence write path.
- Migrated `ProjectMWrapper` projectM pathways to reduce mixed key usage:
  - Toggle write paths now route through facade methods.
  - Property-change dispatch now uses canonical `SettingsConfigKeys` constants for migrated projectM keys.
  - Added explicit `projectM.beatSensitivity` property-change handling.
- Added/updated concise inline documentation in `ConfigurationFacade` projectM methods to match existing facade comment style.

## Design Pattern
- Pattern used: **Facade**
- Category: **Structural**

## Verification
- Build: `cmake --build build` (pass)
- Focused tests: `ctest --test-dir build --output-on-failure -R "projectMSDL-renderer-test|projectMSDL-ui-test"` (pass, 2/2)
- Manual verification: All menu toggles (Lock Preset, Enable Shuffle, Display Toast Messages) and Beat Sensitivity slider confirmed functional. Note: settings do not persist across sessions — confirmed same behavior on `master`; pre-existing issue, not introduced by this refactor.

## Evidence
- Anti-pattern addressed: Shotgun Surgery from mixed projectM config access styles (view-relative + full keys) spread across GUI and runtime wrapper paths.
- Pattern used: Facade (Structural).
- Responsibility mapping:
  - Before: `MainMenu` and `ProjectMWrapper` directly mixed raw key strings and defaults.
  - After: migrated toggle/persistence pathways consume typed `ConfigurationFacade.projectM()` methods with canonical key constants in wrapper property dispatch.
- Behavioral intent: no user-visible behavior change; refactor centralizes migrated settings access and update paths.

## Time Log
- Triage and understanding: 30m
- Plan: 45m
- Implementation: 75m
- Verification: 30m
- PR overhead: 15m

## Additional Changes
Due to GitHub migrating to a new Visual Studio actions version, the buildcheck.yaml needed to be adjusted to use Visual Studio 18 2026 in order to continue building correctly on GitHub. This was addressed in branch p3/issue-61-sdl-flow and commit [59d839b](https://github.com/riley-1995/frontend-sdl2/pull/70/commits/59d839b27a40e18f7d231336555a46f99babe702) was cherrypicked from that branch and merged into the current branch, to resolve the issue while avoiding upstream merge conflicts.
