### PR TITLE
630:P3 Refactor audio config usage through facade

### DIFF
--- a/src/AudioCapture.cpp
+++ b/src/AudioCapture.cpp
@@ -17,7 +17,9 @@ const char* AudioCapture::name() const
 
 void AudioCapture::initialize(Poco::Util::Application& app)
 {
-    _config = app.config().createView("audio");
+    // Construct a facade over the full effective config. AudioCapture only reads
+    // audio settings, so both layers point to the same merged configuration source.
+    ConfigurationFacade::AudioConfigFacade audioConfig(app.config(), app.config());
 
     auto& projectMWrapper = app.getSubsystem<ProjectMWrapper>();
 
@@ -27,9 +29,9 @@ void AudioCapture::initialize(Poco::Util::Application& app)
     }
 
     auto deviceList = _impl->AudioDeviceList();
-    int audioDeviceIndex = GetInitialAudioDeviceIndex(deviceList);
+    int audioDeviceIndex = GetInitialAudioDeviceIndex(deviceList, audioConfig);
 
-    PrintDeviceList(deviceList);
+    PrintDeviceList(deviceList, audioConfig);
 
     _impl->StartRecording(projectMWrapper.ProjectM(), audioDeviceIndex);
 }
@@ -102,9 +104,10 @@ void AudioCapture::FillBuffer()
     _impl->FillBuffer();
 }
 
-void AudioCapture::PrintDeviceList(const AudioDeviceMap& deviceList) const
+void AudioCapture::PrintDeviceList(const AudioDeviceMap& deviceList,
+                                    const ConfigurationFacade::AudioConfigFacade& audioConfig) const
 {
-    if (_config->getBool("listDevices", false))
+    if (audioConfig.listDevices())
     {
         poco_information(_logger, "Available audio capturing devices:");
         for (const auto& device : deviceList)
@@ -114,14 +117,15 @@ void AudioCapture::PrintDeviceList(const AudioDeviceMap& deviceList) const
     }
 }
 
-int AudioCapture::GetInitialAudioDeviceIndex(const AudioDeviceMap& deviceList)
+int AudioCapture::GetInitialAudioDeviceIndex(const AudioDeviceMap& deviceList,
+                                              const ConfigurationFacade::AudioConfigFacade& audioConfig)
 {
     int audioDeviceIndex{ -1 };
 
     // Check if configured device is a number or string
     try
     {
-        audioDeviceIndex = _config->getInt("device", -1);
+        audioDeviceIndex = audioConfig.deviceIndex();
         if (deviceList.find(audioDeviceIndex) == deviceList.end())
         {
             poco_debug(_logger,
@@ -131,7 +135,7 @@ int AudioCapture::GetInitialAudioDeviceIndex(const AudioDeviceMap& deviceList)
     }
     catch (Poco::SyntaxException& ex)
     {
-        auto audioDeviceName = _config->getString("device", "");
+        auto audioDeviceName = audioConfig.deviceName();
 
         poco_debug_f1(_logger, R"(audio.device is set to non-numerical value. Searching for device name "%s".)",
                       audioDeviceName);

--- a/src/AudioCapture.h
+++ b/src/AudioCapture.h
@@ -1,9 +1,10 @@
 #pragma once
 
+#include "config/ConfigurationFacade.h"
+
 #include <Poco/Logger.h>
 
 #include <Poco/Util/Subsystem.h>
-#include <Poco/Util/AbstractConfiguration.h>
 
 #include <memory>
 
@@ -63,8 +64,10 @@ protected:
     /**
      * @brief Prints a list of available audio devices on standard output if requested by the user.
      * @param deviceList The list of available audio devices.
+     * @param audioConfig The audio configuration facade used to check the listDevices flag.
      */
-    void PrintDeviceList(const AudioDeviceMap&  deviceList) const;
+    void PrintDeviceList(const AudioDeviceMap& deviceList,
+                         const ConfigurationFacade::AudioConfigFacade& audioConfig) const;
 
     /**
      * @brief Returns the index of the initial audio device that should be used.
@@ -76,11 +79,11 @@ protected:
      * implementation.
      *
      * @param deviceList The list of available audio devices.
+     * @param audioConfig The audio configuration facade used to read device index and name.
      * @return A device index from -1 to the number of available devices minus one.
      */
-    int GetInitialAudioDeviceIndex(const AudioDeviceMap& deviceList);
-
-    Poco::AutoPtr<Poco::Util::AbstractConfiguration> _config; //!< View of the "audio" configuration subkey.
+    int GetInitialAudioDeviceIndex(const AudioDeviceMap& deviceList,
+                                   const ConfigurationFacade::AudioConfigFacade& audioConfig);
 
     AudioCaptureImpl* _impl{}; //!< The OS-specific capture implementation.
 

--- a/src/ProjectMSDLApplication.cpp
+++ b/src/ProjectMSDLApplication.cpp
@@ -9,6 +9,7 @@
 #include "RenderLoop.h"
 #include "SDLRenderingWindow.h"
 #include "config/ConfigMigration.h"
+#include "config/SettingsConfigKeys.h"
 #include "gui/ProjectMGUI.h"
 
 #include <Poco/Environment.h>
@@ -134,7 +135,7 @@ void ProjectMSDLApplication::defineOptions(Poco::Util::OptionSet& options)
                              "Select an audio device to record from initially. Can be the numerical ID or the full device name. "
                              "If the device is not found, the default device will be used instead.",
                              false, "<id or name>", true)
-                          .binding("audio.device", _commandLineOverrides));
+                          .binding(SettingsConfigKeys::kConfigAudioDevice, _commandLineOverrides));
 
     options.addOption(Option("presetPath", "p", "Base directory to search for presets.",
                              false, "<path>", true)
@@ -281,5 +282,5 @@ Built against SDL version: %?d.%?d.%?d (running with %?d.%?d.%?d))",
 
 void ProjectMSDLApplication::ListAudioDevices(POCO_UNUSED const std::string& name, POCO_UNUSED const std::string& value)
 {
-    _commandLineOverrides->setBool("audio.listDevices", true);
+    _commandLineOverrides->setBool(SettingsConfigKeys::kConfigAudioListDevices, true);
 }

--- a/src/config/ConfigurationFacade.cpp
+++ b/src/config/ConfigurationFacade.cpp
@@ -25,6 +25,9 @@ constexpr bool kProjectMPresetLockedDefault = false;
 constexpr bool kProjectMShuffleEnabledDefault = true;
 constexpr bool kProjectMDisplayToastsDefault = true;
 constexpr double kProjectMBeatSensitivityDefault = 1.0;
+constexpr bool kAudioListDevicesDefault = false;
+constexpr int kAudioDeviceIndexDefault = -1;
+constexpr char kAudioDeviceNameDefault[] = "";
 } // namespace
 
 // WindowConfigFacade implementation
@@ -224,6 +227,37 @@ ConfigurationFacade::AudioConfigFacade::AudioConfigFacade(Poco::Util::AbstractCo
 {
 }
 
+bool ConfigurationFacade::AudioConfigFacade::listDevices() const
+{
+    // Read whether available devices should be logged to the console at startup.
+    // Set to true via the --listAudioDevices CLI flag.
+    return _effectiveConfig.getBool(SettingsConfigKeys::kConfigAudioListDevices, kAudioListDevicesDefault);
+}
+
+int ConfigurationFacade::AudioConfigFacade::deviceIndex() const
+{
+    // Read audio.device as a numeric index. Throws Poco::SyntaxException if the value
+    // is a non-numeric string — callers should catch and fall back to deviceName().
+    return _effectiveConfig.getInt(SettingsConfigKeys::kConfigAudioDevice, kAudioDeviceIndexDefault);
+}
+
+std::string ConfigurationFacade::AudioConfigFacade::deviceName() const
+{
+    // Read audio.device as a string name, used when the value is not a plain integer.
+    return _effectiveConfig.getString(SettingsConfigKeys::kConfigAudioDevice, kAudioDeviceNameDefault);
+}
+
+void ConfigurationFacade::AudioConfigFacade::setDevice(int index)
+{
+    // Persist an integer device index to the user configuration layer.
+    _userConfig.setInt(SettingsConfigKeys::kConfigAudioDevice, index);
+}
+
+void ConfigurationFacade::AudioConfigFacade::setDevice(const std::string& name)
+{
+    // Persist a device name string to the user configuration layer.
+    _userConfig.setString(SettingsConfigKeys::kConfigAudioDevice, name);
+}
 
 // ConfigurationFacade implementation
 ConfigurationFacade::ConfigurationFacade(Poco::Util::AbstractConfiguration& effectiveConfig,

--- a/src/config/ConfigurationFacade.h
+++ b/src/config/ConfigurationFacade.h
@@ -207,7 +207,11 @@ public:
     };
 
     /**
-     * @brief Placeholder facade for audio-scoped settings.
+     * @brief Facade for audio-scoped configuration access.
+     *
+     * Reads values from the effective (merged) configuration and persists writable values
+     * to the user configuration layer. Provides a single typed API for all audio settings
+     * used by capture, settings UI, and CLI, replacing scattered raw key lookups.
      */
     class AudioConfigFacade
     {
@@ -220,8 +224,48 @@ public:
         AudioConfigFacade(Poco::Util::AbstractConfiguration& effectiveConfig,
                           Poco::Util::AbstractConfiguration& userConfig);
 
+        /**
+         * @brief Returns whether available audio devices should be listed at startup.
+         * @return True if the device list should be logged on startup.
+         */
+        bool listDevices() const;
+
+        /**
+         * @brief Returns the configured audio device as a numeric index.
+         *
+         * Reads audio.device as an integer. Throws Poco::SyntaxException if the
+         * configured value is a non-numeric string — callers should catch and fall
+         * back to deviceName() in that case.
+         *
+         * @return Device index, or -1 if unset (default capture device).
+         */
+        int deviceIndex() const;
+
+        /**
+         * @brief Returns the configured audio device as a string name.
+         *
+         * Used as a fallback when the audio.device value is a non-numeric name.
+         *
+         * @return Device name string, or empty string if unset.
+         */
+        std::string deviceName() const;
+
+        /**
+         * @brief Persists an audio device selection by numeric index.
+         * @param index Device index as reported by the capture API, or -1 for default.
+         */
+        void setDevice(int index);
+
+        /**
+         * @brief Persists an audio device selection by name.
+         * @param name Full device name string as reported by the capture API.
+         */
+        void setDevice(const std::string& name);
+
     private:
+        // Effective config includes defaults plus persisted overrides.
         Poco::Util::AbstractConfiguration& _effectiveConfig;
+        // User config is the writable layer persisted to disk.
         Poco::Util::AbstractConfiguration& _userConfig;
     };
 

--- a/src/config/SettingsConfigKeys.h
+++ b/src/config/SettingsConfigKeys.h
@@ -46,6 +46,7 @@ constexpr char kConfigFullscreenHeight[] = "window.fullscreen.height";
 
 // Audio/input and app bootstrap keys.
 constexpr char kConfigAudioDevice[] = "audio.device";
+constexpr char kConfigAudioListDevices[] = "audio.listDevices";
 constexpr char kConfigAppUserConfigurationFile[] = "app.UserConfigurationFile";
 
 } // namespace SettingsConfigKeys


### PR DESCRIPTION
Closes #54

## Summary of Changes
- Added `kConfigAudioListDevices` constant to `SettingsConfigKeys.h` for the `audio.listDevices` key (previously only a raw string in the CLI handler).
- Expanded `ConfigurationFacade::AudioConfigFacade` with typed audio methods: `listDevices()`, `deviceIndex()`, `deviceName()` (read), and `setDevice(int)` / `setDevice(const std::string&)` (write).
- Migrated `AudioCapture` off its raw `createView("audio")` config view:
  - `PrintDeviceList` and `GetInitialAudioDeviceIndex` now accept a `const AudioConfigFacade&` parameter instead of reading from `_config` directly.
  - Raw `_config->getBool("listDevices", …)`, `_config->getInt("device", …)`, and `_config->getString("device", …)` calls replaced with typed facade accessors.
  - `_config` member removed from `AudioCapture`.
- Updated `ProjectMSDLApplication` CLI handler and `--audioDevice` binding to use `SettingsConfigKeys::kConfigAudioListDevices` and `kConfigAudioDevice` constants instead of raw string literals.

## Design Pattern
- Pattern used: **Facade**
- Category: **Structural**

## Verification
- Build: `cmake --build build` (pass)
- Tests: `ctest --test-dir cmake-build-tests --output-on-failure` (pass, 5/5)
- Manual verification: device list flag and device selection behavior confirmed unchanged; `AudioSettingsTab` device combo continues to function as before.

## Evidence
- Anti-pattern addressed: Shotgun Surgery from split audio config access styles — `AudioCapture` used view-relative keys (`"device"`, `"listDevices"`) while the settings UI and CLI used canonical constants.
- Pattern used: Facade (Structural).
- Responsibility mapping:
  - Before: `AudioCapture` owned a `createView("audio")` sub-config and accessed raw relative keys. `ProjectMSDLApplication` used raw `"audio.listDevices"` string in CLI handler.
  - After: `AudioConfigFacade` is the single typed entry point for audio config reads. `AudioCapture` receives a const facade reference with no direct config coupling. CLI handler uses a `SettingsConfigKeys` constant.
- Behavioral intent: no user-visible behavior change; refactor centralizes audio config key ownership in the facade.

## Time Log
- Triage and planning: 30m
- Implementation: 45m
- Verification: 15m
- PR overhead: 15m
